### PR TITLE
feat: add Kotlin 2.0 Compose Compiler plugin support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,12 +5,19 @@ buildscript {
   repositories {
     google()
     mavenCentral()
+    gradlePluginPortal()
   }
 
   dependencies {
     classpath "com.android.tools.build:gradle:7.2.1"
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+
+    // Compose Compiler plugin for Kotlin 2.0+ compatibility
+    // For Kotlin 1.x, this plugin is not required
+    if (kotlin_version.startsWith("2.")) {
+      classpath "org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:$kotlin_version"
+    }
   }
 }
 
@@ -32,6 +39,12 @@ if (isNewArchitectureEnabled()) {
 
 def getExtOrDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties["DotlottieReactNative_" + name]
+}
+
+// Apply Compose Compiler plugin for Kotlin 2.0+
+def kotlin_version_for_compose = getExtOrDefault("kotlinVersion")
+if (kotlin_version_for_compose.startsWith("2.")) {
+  apply plugin: "org.jetbrains.kotlin.plugin.compose"
 }
 
 def getExtOrIntegerDefault(name) {
@@ -62,8 +75,12 @@ android {
        compose = true
   }
 
-  composeOptions {
-       kotlinCompilerExtensionVersion = "1.5.10"
+  // For Kotlin 1.x, we need to specify the compiler extension version
+  // For Kotlin 2.0+, this is handled by the Compose Compiler plugin
+  if (!kotlin_version_for_compose.startsWith("2.")) {
+    composeOptions {
+         kotlinCompilerExtensionVersion = "1.5.10"
+    }
   }
 
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")


### PR DESCRIPTION
- Add gradlePluginPortal() repository for Compose Compiler plugin access
- Conditionally include Compose Compiler plugin classpath for Kotlin 2.0+
- Apply Compose Compiler plugin when Kotlin 2.0+ is detected
- Maintain backward compatibility with Kotlin 1.x by keeping composeOptions

This change addresses forward compatibility concerns raised in #15 while maintaining full compatibility with existing Kotlin 1.7.0 builds.

Related to #15