### PR TITLE
fix(android): prevent IllegalStateException in cleanup on destroyed p…

### DIFF
--- a/android/src/main/java/com/dotlottiereactnative/DotlottieReactNativeView.kt
+++ b/android/src/main/java/com/dotlottiereactnative/DotlottieReactNativeView.kt
@@ -296,15 +296,21 @@ class DotlottieReactNativeView(context: ThemedReactContext) : FrameLayout(contex
   }
 
   private fun cleanup() {
-    dotLottieController.stop()
+    try {
+      dotLottieController.stop()
 
-    if (dotLottieController.stateMachineIsActive) {
-      dotLottieController.stateMachineStop()
+      if (dotLottieController.stateMachineIsActive) {
+        dotLottieController.stateMachineStop()
+      }
+
+      dotLottieController.stateMachineRemoveEventListener(stateMachineEventListener)
+      dotLottieController.clearEventListeners()
+    } catch (e: IllegalStateException) {
+      android.util.Log.w("DotLottie", "cleanup called on already destroyed player: ${e.message}")
+    } catch (e: Exception) {
+      android.util.Log.e("DotLottie", "Error during cleanup: ${e.message}")
+    } finally {
+      composeView.disposeComposition()
     }
-
-    dotLottieController.stateMachineRemoveEventListener(stateMachineEventListener)
-    dotLottieController.clearEventListeners()
-
-    composeView.disposeComposition()
   }
 }


### PR DESCRIPTION
## 🐛 Problem

The app crashes with `IllegalStateException: DotLottiePlayer object has already been destroyed` when a component containing `DotLottie` is unmounted quickly (e.g., closing a BottomSheet or navigating away).

### Stacktrace

java.lang.IllegalStateException: DotLottiePlayer object has already been destroyed
at com.dotlottie.dlplayer.DotLottiePlayer.stop(dotlottie_player.kt:7281)
at com.lottiefiles.dotlottie.core.compose.runtime.DotLottieController.stop(DotLottieController.kt:139)
at com.dotlottiereactnative.DotlottieReactNativeView.cleanup(DotlottieReactNativeView.kt:299)
at com.dotlottiereactnative.DotlottieReactNativeView.onDetachedFromWindow(DotlottieReactNativeView.kt:295)

### Root Cause
Race condition in the cleanup lifecycle:
1. `DotLottiePlayer` object gets destroyed
2. `onDetachedFromWindow()` triggers `cleanup()`
3. `cleanup()` attempts to call `stop()` on the already destroyed player
4. App crashes with `IllegalStateException`

## ✅ Solution

Added try-catch block in the `cleanup()` method to gracefully handle cases where the player is already destroyed. This prevents the crash while still allowing proper cleanup of resources that are still available.

## 🧪 Testing

- [x] Tested with BottomSheet that frequently mounts/unmounts DotLottie component
- [x] Tested rapid navigation between screens with DotLottie animations
- [x] No crashes observed after the fix
- [x] Proper cleanup still occurs when player is not destroyed