### PR TITLE
fix: migrate release workflow to OIDC trusted publishing

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,13 +5,18 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version-file: .nvmrc
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Upgrade npm for OIDC support
+      run: npm install -g npm@latest
+      shell: bash
 
     - name: Cache dependencies
       id: yarn-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           **/node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,9 @@ jobs:
     permissions:
       contents: write
       id-token: write
-      packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -28,9 +27,6 @@ jobs:
       - name: Build package
         run: yarn prepare
 
-      - name: Setup .npmrc (NPM)
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMJS_TOKEN }}" >> ~/.npmrc
-
       - name: Setup Git
         run: |
           git config --global user.name "github-actions[bot]"
@@ -41,4 +37,3 @@ jobs:
         run: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPMJS_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -143,7 +143,11 @@
       "requireCleanWorkingDir": false
     },
     "npm": {
-      "publish": true
+      "publish": true,
+      "skipChecks": true,
+      "publishArgs": [
+        "--provenance --access public"
+      ]
     },
     "github": {
       "release": true


### PR DESCRIPTION
- Replace secret-based npm auth (.npmrc + NPMJS_TOKEN) with OIDC trusted publishing via setup-node registry-url
- Add skipChecks: true to release-it config to skip npm whoami/ping which fail with OIDC tokens
- Add --provenance --access public to npm publish args
- Upgrade npm to latest in setup action since Node 20 bundles npm v10.8 but OIDC requires npm >= 11.5.1
- Upgrade actions to v4 (setup-node, cache, checkout)
- Remove unnecessary packages:write permission
