### PR TITLE
chore(deps): bump dotlottie-android to 0.13.6 (fix Android 16 crash)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -121,7 +121,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.github.LottieFiles:dotlottie-android:0.13.4"
+  implementation "com.github.LottieFiles:dotlottie-android:0.13.6"
   implementation 'androidx.compose.ui:ui:1.5.0'
   implementation 'androidx.compose.material:material:1.5.0'
   implementation 'androidx.compose.ui:ui-tooling-preview:1.5.0'


### PR DESCRIPTION
## Summary

- Bumps `dotlottie-android` from `0.13.4` → `0.13.6` in `android/build.gradle`.
- Fixes a `SIGABRT` hard crash on Android 16 Beta (SDK 36) triggered inside the native `dotlottie_stop` call during screen detachment.

## Why

Apps using `dotlottie-react-native` 0.7.4 / 0.8.0 crash on Android 16 Beta (SDK 36, observed on Galaxy S25 / M1S / R12S / M3Q) whenever a screen containing a DotLottie animation is navigated away from. Scudo (Android 16's hardened allocator) detects an invalid chunk state while `dotlottie_stop` calls `realloc`, and aborts:

```
Scudo ERROR: invalid chunk state when reallocating address 0x<sanitized>
  #07  realloc
  #21  dotlottie_stop
  #24  DotLottiePlayer.stop()
  #30  DotlottieReactNativeView.onDetachedFromWindow()
  #47  com.swmansion.rnscreens — screen removal
```

Older Android releases tolerated the double-free; Scudo on SDK 36 does not. The underlying memory-corruption bug is in the native core and was fixed upstream in [`dotlottie-android` 0.13.6](https://github.com/LottieFiles/dotlottie-android/releases/tag/0.13.6):
> fix: 🐛 crash when loading DotLottieDrawable a second time

Reported crash-rate impact from the filer: **+3.99pp spike** in Google Play Console Android Vitals.

Closes #45.

## References

- dotlottie-android 0.13.6 release: https://github.com/LottieFiles/dotlottie-android/releases/tag/0.13.6
- Upstream crash issue: https://github.com/LottieFiles/dotlottie-android/issues/96