### PR TITLE
Enhance README with title and logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# dotLottie React Native
+<p align="center">
+  <img
+    src="https://lottie.host/efe1eb25-5273-4f3f-b738-b83ddf25e721/YlQbabUaOf.svg"
+    alt="dotLottie React Native"
+    width="300"
+  />
+</p>
+
+<h1 align="center">dotLottie React Native</h1>
 
 Lottie & dotLottie component for React Native ([iOS](https://github.com/LottieFiles/dotlottie-ios/), [Android](https://github.com/LottieFiles/dotlottie-android/), and [Web](https://github.com/LottieFiles/dotlottie-web))
 


### PR DESCRIPTION
Add header and image to README for dotLottie React Native

<img width="300" alt="INFCON_Dotlottie json" src="https://github.com/user-attachments/assets/cc9eba00-8b6f-4183-b303-5af559b868be" />
