### PR TITLE
fix(android): pick source loader from URI scheme

### DIFF
--- a/android/src/main/java/com/dotlottiereactnative/DotlottieReactNativeView.kt
+++ b/android/src/main/java/com/dotlottiereactnative/DotlottieReactNativeView.kt
@@ -1,9 +1,11 @@
 package com.dotlottiereactnative
 
 import android.graphics.Color
+import android.net.Uri
 import android.widget.FrameLayout
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import com.dotlottie.dlplayer.Mode
 import com.facebook.react.bridge.Arguments
@@ -114,7 +116,7 @@ class DotlottieReactNativeView(context: ThemedReactContext) : FrameLayout(contex
   @Composable
   fun DotLottieContent() {
     animationUrl.value?.let { url ->
-      val source = DotLottieSource.Url(url)
+      val source = remember(url) { resolveDotLottieSource(url) }
 
       if (useOpenGLRenderer) {
         DotLottieGLAnimation(
@@ -147,6 +149,41 @@ class DotlottieReactNativeView(context: ThemedReactContext) : FrameLayout(contex
                 eventListeners = eventListeners
         )
       }
+    }
+  }
+
+
+  private fun resolveDotLottieSource(url: String): DotLottieSource {
+    return when {
+      url.startsWith("http://") || url.startsWith("https://") ->
+              DotLottieSource.Url(url)
+
+      url.startsWith("file:///android_asset/") ->
+              DotLottieSource.Asset(url.removePrefix("file:///android_asset/"))
+
+      url.startsWith("file://") || url.startsWith("content://") ->
+              readSourceBytes(url)?.let { DotLottieSource.Data(it) } ?: DotLottieSource.Url(url)
+
+      else -> resolveResourceSource(url) ?: DotLottieSource.Url(url)
+    }
+  }
+
+  private fun resolveResourceSource(name: String): DotLottieSource? {
+    val resId =
+            reactContext.resources.getIdentifier(name, "raw", reactContext.packageName)
+                    .takeIf { it != 0 }
+                    ?: reactContext.resources
+                            .getIdentifier(name, "drawable", reactContext.packageName)
+                            .takeIf { it != 0 }
+    return resId?.let { DotLottieSource.Res(it) }
+  }
+
+  private fun readSourceBytes(uri: String): ByteArray? {
+    return try {
+      reactContext.contentResolver.openInputStream(Uri.parse(uri))?.use { it.readBytes() }
+    } catch (e: Exception) {
+      android.util.Log.e("DotLottie", "Failed to read source bytes from $uri: ${e.message}")
+      null
     }
   }
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -10,6 +10,7 @@ import {
 import { LifecycleExample } from './examples/LifecycleExample';
 import { StateMachineExample } from './examples/StateMachineExample';
 import { MultipleAnimationsTest } from './examples/MultipleAnimationsTest';
+import { SourceLoadingExample } from './examples/SourceLoadingExample';
 
 type ExampleDescriptor = {
   key: string;
@@ -19,6 +20,13 @@ type ExampleDescriptor = {
 };
 
 const EXAMPLES: ExampleDescriptor[] = [
+  {
+    key: 'source-loading',
+    title: 'Source Loading (issue #50)',
+    description:
+      'Verifies local require() and remote URL sources render, incl. Android release builds.',
+    Component: SourceLoadingExample,
+  },
   {
     key: 'multiple-animations',
     title: 'Multiple Animations Test',

--- a/example/examples/SourceLoadingExample.tsx
+++ b/example/examples/SourceLoadingExample.tsx
@@ -10,10 +10,6 @@ const STATUS_LABEL: Record<LoadState, string> = {
   error: '❌ load error',
 };
 
-// Verifies that each source kind renders. The local require() case is the one
-// that regressed on Android release builds (see issue #50): in debug it is
-// served over http by Metro, but in release it resolves to a file://
-// /android_asset URI that the URL loader could not fetch.
 function SourceCase({
   title,
   source,

--- a/example/examples/SourceLoadingExample.tsx
+++ b/example/examples/SourceLoadingExample.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { DotLottie } from '@lottiefiles/dotlottie-react-native';
+
+type LoadState = 'pending' | 'loaded' | 'error';
+
+const STATUS_LABEL: Record<LoadState, string> = {
+  pending: '… loading',
+  loaded: '✅ loaded',
+  error: '❌ load error',
+};
+
+// Verifies that each source kind renders. The local require() case is the one
+// that regressed on Android release builds (see issue #50): in debug it is
+// served over http by Metro, but in release it resolves to a file://
+// /android_asset URI that the URL loader could not fetch.
+function SourceCase({
+  title,
+  source,
+}: {
+  title: string;
+  source: number | { uri: string };
+}) {
+  const [state, setState] = useState<LoadState>('pending');
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>{title}</Text>
+      <Text
+        style={[
+          styles.status,
+          state === 'loaded' && styles.statusOk,
+          state === 'error' && styles.statusErr,
+        ]}
+      >
+        {STATUS_LABEL[state]}
+      </Text>
+      <View style={styles.animationBox}>
+        <DotLottie
+          source={source}
+          style={styles.animation}
+          autoplay
+          loop
+          onLoad={() => setState('loaded')}
+          onLoadError={() => setState('error')}
+        />
+      </View>
+    </View>
+  );
+}
+
+export function SourceLoadingExample() {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <SourceCase
+        title="Local require() — regressed on Android release"
+        source={require('../assets/star-rating.lottie')}
+      />
+      <SourceCase
+        title="Remote HTTPS URL"
+        source={{
+          uri: 'https://lottie.host/50f65a48-2f50-432f-b47a-4e6b271625c0/O4jvHbwypB.lottie',
+        }}
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    gap: 16,
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    gap: 8,
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#000',
+  },
+  status: {
+    fontSize: 14,
+    color: '#888',
+  },
+  statusOk: {
+    color: '#1a7f37',
+    fontWeight: '600',
+  },
+  statusErr: {
+    color: '#cf222e',
+    fontWeight: '600',
+  },
+  animationBox: {
+    height: 200,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#f6f8fa',
+    borderRadius: 8,
+  },
+  animation: {
+    width: 180,
+    height: 180,
+  },
+});


### PR DESCRIPTION
On Android every source went through `DotLottieSource.Url`, so anything that wasn't an http(s) URL silently failed: local `require()` in release builds and `file://` URIs from expo-asset. Debug worked only because Metro serves bundled assets over http.

Now the loader is chosen from the URI, matching the iOS side:

- `http(s)://` → `Url`
- `file:///android_asset/` → `Asset`
- `file://` / `content://` → `Data`
- bundled resource name → `Res`
- otherwise → `Url`

Fixes #50