### PR TITLE
chore(deps): bump dotlottie-android, dotlottie-react, AndroidX Compose, AGP, and Kotlin defaults

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:7.2.1"
+    classpath "com.android.tools.build:gradle:8.7.2"
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
@@ -102,8 +102,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
 }
 
@@ -122,9 +122,9 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.github.LottieFiles:dotlottie-android:0.13.7"
-  implementation 'androidx.compose.ui:ui:1.5.0'
-  implementation 'androidx.compose.material:material:1.5.0'
-  implementation 'androidx.compose.ui:ui-tooling-preview:1.5.0'
-  implementation 'androidx.activity:activity-compose:1.8.0'
+  implementation 'androidx.compose.ui:ui:1.9.5'
+  implementation 'androidx.compose.material:material:1.9.5'
+  implementation 'androidx.compose.ui:ui-tooling-preview:1.9.5'
+  implementation 'androidx.activity:activity-compose:1.10.1'
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -121,7 +121,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.github.LottieFiles:dotlottie-android:0.13.7"
+  implementation "com.github.LottieFiles:dotlottie-android:0.13.8"
   implementation 'androidx.compose.ui:ui:1.9.5'
   implementation 'androidx.compose.material:material:1.9.5'
   implementation 'androidx.compose.ui:ui-tooling-preview:1.9.5'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-DotlottieReactNative_kotlinVersion=1.7.0
+DotlottieReactNative_kotlinVersion=2.1.20
 DotlottieReactNative_minSdkVersion=24
 DotlottieReactNative_targetSdkVersion=35
 DotlottieReactNative_compileSdkVersion=35

--- a/dotlottie-react-native.podspec
+++ b/dotlottie-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'LottieFiles-dotLottie-iOS', '~> 0.15.4'
+  s.dependency 'LottieFiles-dotLottie-iOS', '~> 0.15.5'
 
   s.swift_version = '5.0'
 

--- a/dotlottie-react-native.podspec
+++ b/dotlottie-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'LottieFiles-dotLottie-iOS', '~> 0.15.5'
+  s.dependency 'LottieFiles-dotLottie-iOS', '~> 0.15.4'
 
   s.swift_version = '5.0'
 

--- a/package.json
+++ b/package.json
@@ -222,6 +222,6 @@
     "version": "0.40.0"
   },
   "dependencies": {
-    "@lottiefiles/dotlottie-react": "^0.18.7"
+    "@lottiefiles/dotlottie-react": "^0.19.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3063,7 +3063,7 @@ __metadata:
     "@commitlint/config-conventional": ^17.0.2
     "@evilmartians/lefthook": ^1.5.0
     "@expo/config-plugins": ^8.0.0
-    "@lottiefiles/dotlottie-react": ^0.18.7
+    "@lottiefiles/dotlottie-react": ^0.19.4
     "@react-native/eslint-config": ^0.73.1
     "@release-it/conventional-changelog": ^10.0.1
     "@types/jest": ^29.5.13
@@ -3087,21 +3087,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lottiefiles/dotlottie-react@npm:^0.18.7":
-  version: 0.18.7
-  resolution: "@lottiefiles/dotlottie-react@npm:0.18.7"
+"@lottiefiles/dotlottie-react@npm:^0.19.4":
+  version: 0.19.4
+  resolution: "@lottiefiles/dotlottie-react@npm:0.19.4"
   dependencies:
-    "@lottiefiles/dotlottie-web": 0.67.0
+    "@lottiefiles/dotlottie-web": 0.74.0
   peerDependencies:
     react: ^17 || ^18 || ^19
-  checksum: ac611833fbb65fcbe66d42a4efdd731f4c665903b3554734d04f8ade0ae5c4c03d6be0978ecce5716c0b7d66ea00b20e3503046df6e8207dd78668eeab3eeffc
+  checksum: aebf50b16e1fed840d245bd28bcfd87d3bdece9533dae3a021a9c4d73eebe6be1828c2eb55e3ddb19ad70d202b72d8fd4edb89855ec8d293d9bc550afc29181f
   languageName: node
   linkType: hard
 
-"@lottiefiles/dotlottie-web@npm:0.67.0":
-  version: 0.67.0
-  resolution: "@lottiefiles/dotlottie-web@npm:0.67.0"
-  checksum: eb0d1b38921f012892efdb4e2770711d50c358966d8cec70a310d6e60f64d5da45fed8cb0997141b3b4a0b78f5617990b23a778d129637f3acf0f1458c3bb0c1
+"@lottiefiles/dotlottie-web@npm:0.74.0":
+  version: 0.74.0
+  resolution: "@lottiefiles/dotlottie-web@npm:0.74.0"
+  checksum: a9e71f5c980ab1f6c2212ab2b1f361fb30f9ce2ff29d7c51bf9202da6cf141867cd7c4e93fdc94f1ff964b50a73416247e29c5145add9d2f78b8099f29487c0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Production-affecting dependency bumps for the library. Covers the npm prod dep, the iOS pod, the native Android player, and the Android toolchain (Compose, AGP, Kotlin default).

| Where | Package | Before | After |
|---|---|---|---|
| `package.json` deps | `@lottiefiles/dotlottie-react` (web fallback player) | `^0.18.7` | `^0.19.4` |
| `*.podspec` | `LottieFiles-dotLottie-iOS` | `~> 0.15.4` | `~> 0.15.4` (unchanged; see note) |
| `android/build.gradle` | `com.github.LottieFiles:dotlottie-android` | `0.13.7` | `0.13.8` |
| `android/build.gradle` (buildscript) | `com.android.tools.build:gradle` (AGP) | `7.2.1` | `8.7.2` |
| `android/build.gradle` | Java source/target compatibility | `1.8` | `11` |
| `android/build.gradle` | `androidx.compose.ui:ui` + `material` + `ui-tooling-preview` | `1.5.0` | `1.9.5` |
| `android/build.gradle` | `androidx.activity:activity-compose` | `1.8.0` | `1.10.1` |
| `android/gradle.properties` | `DotlottieReactNative_kotlinVersion` (default) | `1.7.0` | `2.1.20` |

### Why these specific values

- **`dotlottie-android` 0.13.8**: latest release (2026-05-26). Upstream fix: stops consuming pointer events when `stateMachineId` is not provided.
- **`LottieFiles-dotLottie-iOS` pin held at `~> 0.15.4`**: an interim bump to `~> 0.15.5` was made and then reverted because `0.15.5` has a GitHub release but has not been pushed to the CocoaPods trunk, so the stricter pin made `pod install` fail. The pessimistic `~> 0.15.4` operator (semver: `>= 0.15.4, < 0.16`) will automatically pick up `0.15.5` once upstream publishes — no future bump required.
- **Kotlin 2.1.20 + AGP 8.7.2**: matches what `example/android/build.gradle` already uses, so the library's own defaults are now consistent with how it's tested.
- **Compose 1.9.5 + activity-compose 1.10.1**: latest stable lines. Library `compileSdk=35` already satisfies the floors (Compose 1.8+ needs 35, activity-compose 1.10+ needs 35).
- **Java 11**: AGP 8.x minimum.
- The existing `if (kotlin_version.startsWith("2."))` conditional in `android/build.gradle` auto-applies the Compose Compiler gradle plugin for Kotlin 2.x, so the old `kotlinCompilerExtensionVersion = "1.5.10"` path is no longer hit on the default. (It remains as a fallback for any consumer who pins back to Kotlin 1.x.)
- Fixes a latent incompatibility: previous default Kotlin `1.7.0` paired with compose-compiler `1.5.10` (which requires Kotlin `1.9.22`) was a broken combination. Only worked in practice because RN 0.81 host apps override `kotlinVersion` to 2.x.

## Verified locally

- `yarn typecheck` clean
- `yarn lint` clean (only transitive caniuse-lite freshness warnings)
- `yarn prepare` (bob build for commonjs/module/typescript targets) clean — confirms `dotlottie-react@0.19.4` type surface still satisfies `DotLottie.web.tsx`

## Test plan

- [ ] `yarn android:paper` — example app builds and renders DotLottie animations on Android (Paper) with `dotlottie-android@0.13.8`
- [ ] `yarn android:fabric` — example app builds and renders on Android (Fabric / new arch)
- [ ] `yarn expo:android` — expo example builds and the plugin autolinks correctly
- [ ] `yarn ios:paper` — example app builds and renders on iOS (Paper) with dotLottie-iOS 0.15.4
- [ ] `yarn ios:fabric` — example app builds and renders on iOS (Fabric / new arch)
- [ ] Smoke-test the web fallback (e.g. `yarn expo:start --web`) — verify imperative API (`play`, `pause`, `setMode`, `setTheme`, `loadAnimation`, state machine) and events (`load`, `complete`, `loop`, `frame`, etc.) still behave under `dotlottie-react@0.19.4`