### PR TITLE
chore: sync version to published 0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lottiefiles/dotlottie-react-native",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "dotlottie react native",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
## Why

The `Release` workflow has been failing because **npm and git are out of sync**.

The 2026-05-27 release run ([`26516422780`](https://github.com/LottieFiles/dotlottie-react-native/actions/runs/26516422780)) did this:

```
✔ npm publish   → 0.9.2 published to npm (permanent)
✔ git commit / git tag (local)
✖ git push      → rejected: GH013 repository rule violations for refs/heads/main
                   "5 of 5 required status checks are expected"
```

So `0.9.2` exists on npm (and is the `latest` tag) but the version bump never landed here — `package.json` is still `0.9.1`. Every subsequent release run recomputes `0.9.1 → 0.9.2` and dies with `cannot publish over the previously published versions: 0.9.2`.

The published `0.9.2` was built from #58 and is **missing the #59 iOS navigation-crash fix** (its podspec pins `dotlottie-ios 0.15.5`; `main` pins `0.15.6`). npm versions are immutable, so we roll forward.

## What this does

Bumps `package.json` to `0.9.2` to match what npm already published. After this merges, re-running the **Release** workflow computes `0.9.2 → 0.9.3` and ships the #59 fix.

## Required before re-running Release

The push-back to `main` will keep failing until the release bot can bypass the branch ruleset (`refs/heads/main`). See the run logs above.

## Follow-ups
- A `v0.9.2` tag (pointing at the commit npm 0.9.2 was built from, `1a3986b`) is being added separately to reconcile tag history.