### PR TITLE
fix: prevent Android "Cannot locate windowRecomposer" crash when measured before window attach

### DIFF
--- a/.changeset/fix-android-windowrecomposer-crash.md
+++ b/.changeset/fix-android-windowrecomposer-crash.md
@@ -1,0 +1,7 @@
+---
+"@lottiefiles/dotlottie-react-native": patch
+---
+
+Fix an Android crash ("Cannot locate windowRecomposer") when a `<DotLottie>` is
+measured before its window is attached under the React Native new architecture
+(Fabric) — e.g. navigating to a screen that renders it via react-native-screens.

--- a/android/src/main/java/com/dotlottiereactnative/DotlottieReactNativeView.kt
+++ b/android/src/main/java/com/dotlottiereactnative/DotlottieReactNativeView.kt
@@ -41,6 +41,19 @@ class DotlottieReactNativeView(context: ThemedReactContext) : FrameLayout(contex
   private var stateMachineListenerRegistered: Boolean = false
   private var hasActiveComposition: Boolean = false
   private var isReleased: Boolean = false
+  private var hasAttachedToWindow: Boolean = false
+
+  private val measureAndLayout =
+          Runnable {
+            if (!hasAttachedToWindow || width <= 0 || height <= 0) {
+              return@Runnable
+            }
+            measure(
+                    MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+                    MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+            )
+            layout(left, top, right, bottom)
+          }
 
   private val composeView: ComposeView =
           ComposeView(context).apply {
@@ -50,7 +63,8 @@ class DotlottieReactNativeView(context: ThemedReactContext) : FrameLayout(contex
   init {
     addView(composeView)
     ensureStateMachineListener()
-    renderContent()
+    // Composition is created once the view is attached (onAttachedToWindow /
+    // setSource); creating it here while detached is unnecessary.
   }
 
   fun onReceiveNativeEvent(eventName: String, value: WritableMap?) {
@@ -414,11 +428,14 @@ class DotlottieReactNativeView(context: ThemedReactContext) : FrameLayout(contex
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
+    hasAttachedToWindow = false
+    removeCallbacks(measureAndLayout)
     cleanup()
   }
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
+    hasAttachedToWindow = true
     if (isReleased) {
       return
     }
@@ -426,6 +443,48 @@ class DotlottieReactNativeView(context: ThemedReactContext) : FrameLayout(contex
     if (!hasActiveComposition) {
       renderContent()
     }
+    scheduleMeasureAndLayout()
+  }
+
+  override fun requestLayout() {
+    super.requestLayout()
+    scheduleMeasureAndLayout()
+  }
+
+  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+    if (!hasAttachedToWindow) {
+      setMeasuredDimension(
+              MeasureSpec.getSize(widthMeasureSpec),
+              MeasureSpec.getSize(heightMeasureSpec)
+      )
+      return
+    }
+
+    super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+  }
+
+  override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+    super.onLayout(changed, left, top, right, bottom)
+    layoutComposeViewIfReady()
+  }
+
+  private fun layoutComposeViewIfReady() {
+    if (!hasAttachedToWindow || width <= 0 || height <= 0) {
+      return
+    }
+    composeView.measure(
+            MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+            MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+    )
+    composeView.layout(0, 0, width, height)
+  }
+
+  private fun scheduleMeasureAndLayout() {
+    if (!hasAttachedToWindow) {
+      return
+    }
+    removeCallbacks(measureAndLayout)
+    post(measureAndLayout)
   }
 
   fun release() {


### PR DESCRIPTION
## Summary

On Android with the React Native new architecture (Fabric), navigating to a
screen that renders `<DotLottie>` crashes with:

```
java.lang.IllegalStateException: Cannot locate windowRecomposer;
  View androidx.compose.ui.platform.ComposeView{…} is not attached to a window
    at androidx.compose.ui.platform.WindowRecomposer_androidKt.getWindowRecomposer(...)
    at androidx.compose.ui.platform.AbstractComposeView.ensureCompositionCreated(...)
    at androidx.compose.ui.platform.AbstractComposeView.onMeasure(...)
    at com.facebook.react.fabric.mounting.SurfaceMountingManager.updateLayout(...)
```

Fixes #33.

## Root cause

Under Fabric, `SurfaceMountingManager` measures a view subtree **before** it is
attached to the window (and `react-native-screens` detaches/re-attaches screens
on navigation). `DotlottieReactNativeView` hosts the animation in a Jetpack
Compose `ComposeView`, whose `onMeasure` eagerly creates its composition; that
resolves the window-scoped `Recomposer`, which requires the view to be attached
and throws when it isn't. iOS has no Compose and is unaffected.

## Fix

`ComposeView` is `final`, so the guard lives on the host `FrameLayout`:

- `onMeasure` skips measuring the `ComposeView` child while detached, so no
  composition is created and nothing throws.
- Fabric measures only once (while detached) and does not re-measure after
  attach, so skipping alone would leave the animation blank. `onAttachedToWindow`
  / `onLayout` / `requestLayout` therefore force a measure + layout pass once
  attached so the animation composes and renders. The pass is debounced
  (`removeCallbacks` + `post`) and gated on attachment + non-zero size.

## Reproduction

1. New architecture enabled; navigate via react-native-screens
   (`@react-navigation/native-stack` or `stack`).
2. Push a screen that renders `<DotLottie>`.
3. Android crashes with the error above; iOS is fine.

Related: software-mansion/react-native-screens#2821 (same
`ComposeView`-measured-before-attach class of crash).

## Test plan

- Reproduced on RN 0.85 + new architecture. With the fix, navigating to the
  DotLottie screen no longer crashes, the animation renders, and it's stable
  across repeated navigate/dismiss.
- Android-native change only — no JS API change, no iOS impact.

I added a changeset (patch). Flagging per CONTRIBUTING (implementation change);
the crash is documented in #33 — happy to adjust the approach.
